### PR TITLE
Add better selector parsing 🚀.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ travis-ci = { repository = "yamafaktory/jql" }
 
 [dependencies]
 clap = "2.32.0"
+regex= "1.0.5"
 serde_json = "1.0.32"
 toml = "0.4.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 extern crate clap;
+extern crate regex;
 extern crate serde_json;
 extern crate toml;
 


### PR DESCRIPTION
The current implementation is way too simple as you can't select complex JSON notations and officially valid formats as per https://tools.ietf.org/html/rfc8259#section-13, e.g.:

```json
{
  ".property..": "This is valid JSON!",
  "\"": "This is valid JSON as well"
}
```

```json
1337
```

```json
[1, 2, 3]
```

The new parser relies on the Regex crates so that running `jql test.json '".property.."'` is possible