### PR TITLE
Apply filters at the group level not globally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ jql example.json 'laptops|laptop.brand'
 ```
 
 ```sh
-jql example.json 'laptops.1:0,laptops|laptop.brand'
+jql example.json 'laptops.1:0|laptop.brand,laptops|laptop.brand'
 ```
 
 ```json
@@ -240,6 +240,8 @@ jql example.json 'laptops.1:0,laptops|laptop.brand'
   ]
 ]
 ```
+
+Please note that a filter is applied at the group level.
 
 ### Special characters
 

--- a/src/array_walker.rs
+++ b/src/array_walker.rs
@@ -47,7 +47,7 @@ pub fn array_walker(
             // Trying to access an index on a node which is not
             // an array.
             None => {
-                if selectors.len() == 1 {
+                if selectors.len() == 1 || map_index == 0 {
                     ["Root element is not an array"].join(" ")
                 } else {
                     [

--- a/src/group_walker.rs
+++ b/src/group_walker.rs
@@ -8,32 +8,47 @@ use serde_json::Value;
 use types::{Selection, Selector};
 
 /// Walks through a group.
-pub fn group_walker(
-    capture: &regex::Captures<'_>,
-    filter: Option<&str>,
-    json: &Value,
-) -> Selection {
+pub fn group_walker(capture: &regex::Captures<'_>, json: &Value) -> Selection {
     lazy_static! {
+        static ref FILTER_REGEX: Regex =
+            Regex::new(r"^(.*)\|([^|]+)$").unwrap();
         static ref SUB_GROUP_REGEX: Regex =
             Regex::new(r#"("[^"]+")|([^.]+)"#).unwrap();
     }
 
     let group = capture.get(0).map_or("", |m| m.as_str()).trim();
 
+    let group_with_filter: Vec<(&str, &str)> = FILTER_REGEX
+        .captures_iter(group)
+        .map(|capture| {
+            (
+                capture.get(1).map_or("", |m| m.as_str()),
+                capture.get(2).map_or("", |m| m.as_str()),
+            )
+        }).collect();
+
+    let group_and_filter = if group_with_filter.is_empty() {
+        // No filter, use the initial selector.
+        (group, None)
+    } else {
+        // Use the left part before the filter.
+        (group_with_filter[0].0, Some(group_with_filter[0].1))
+    };
+
     // Empty group, return early.
-    if group.is_empty() {
+    if group_and_filter.0.is_empty() {
         return Err(String::from("Empty group"));
     }
 
     // Capture sub-groups of double quoted selectors and simple ones surrounded
     // by dots on the group itself.
     let selectors: Vec<Selector> = SUB_GROUP_REGEX
-        .captures_iter(group)
+        .captures_iter(group_and_filter.0)
         .map(|capture| get_selector(capture.get(0).map_or("", |m| m.as_str())))
         .collect();
 
     // Perform the same operation on the filter.
-    let filter_selectors = match filter {
+    let filter_selectors = match group_and_filter.1 {
         Some(filter) => Some(
             SUB_GROUP_REGEX
                 .captures_iter(filter)
@@ -48,8 +63,8 @@ pub fn group_walker(
     // as soon as the latter is encountered.
     let items: Selection = get_selection(&selectors, &json);
 
-    // Check for empty selection, in this case we assume that the user expects
-    // to get back the complete raw JSON back for this group.
+    // Check for an empty selection, in this case we assume that the user
+    // expects to get back the complete raw JSON for this group.
     match items {
         Ok(items) => {
             if items.is_empty() {

--- a/src/range_selector.rs
+++ b/src/range_selector.rs
@@ -13,48 +13,54 @@ pub fn range_selector(
 ) -> Result<Value, String> {
     let is_default = start < end;
 
-    // Check the range validity.
-    if inner_json.as_array().unwrap().len() < start
-        || inner_json.as_array().unwrap().len() < (end + 1)
-    {
-        return Err(if selectors.len() == 1 {
-            [
-                "Range (",
-                start.to_string().as_str(),
-                ":",
-                end.to_string().as_str(),
-                ") is out of bound, root element has a length of",
-                &(inner_json.as_array().unwrap().len()).to_string(),
-            ]
-                .join(" ")
-        } else {
-            [
-                "Range (",
-                start.to_string().as_str(),
-                ":",
-                end.to_string().as_str(),
-                ") is out of bound,",
-                &display_node_or_range(&selectors[map_index - 1], false),
-                "has a length of",
-                &(inner_json.as_array().unwrap().len()).to_string(),
-            ]
-                .join(" ")
-        });
-    }
+    match inner_json.as_array() {
+        Some(json_array) => {
+            // Check the range validity.
+            if json_array.len() < start || json_array.len() < (end + 1) {
+                return Err(if selectors.len() == 1 {
+                    [
+                        "Range (",
+                        start.to_string().as_str(),
+                        ":",
+                        end.to_string().as_str(),
+                        ") is out of bound, root element has a length of",
+                        &(json_array.len()).to_string(),
+                    ]
+                        .join(" ")
+                } else {
+                    [
+                        "Range (",
+                        start.to_string().as_str(),
+                        ":",
+                        end.to_string().as_str(),
+                        ") is out of bound,",
+                        &display_node_or_range(
+                            &selectors[map_index - 1],
+                            false,
+                        ),
+                        "has a length of",
+                        &(json_array.len()).to_string(),
+                    ]
+                        .join(" ")
+                });
+            }
 
-    Ok(if is_default {
-        json!(inner_json.as_array().unwrap()[start..=end])
-    } else {
-        // Get the normalized slice selection, i.e. from end to start.
-        let normalized_range_selection =
-            json!(inner_json.as_array().unwrap()[end..=start]);
-        // Reverse it.
-        let reversed_range_selection: Vec<&Value> = normalized_range_selection
-            .as_array()
-            .unwrap()
-            .iter()
-            .rev()
-            .collect();
-        json!(reversed_range_selection)
-    })
+            Ok(if is_default {
+                json!(json_array[start..=end])
+            } else {
+                // Get the normalized slice selection, i.e. from end to start.
+                let normalized_range_selection = json!(json_array[end..=start]);
+                // Reverse it.
+                let reversed_range_selection: Vec<&Value> =
+                    normalized_range_selection
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .rev()
+                        .collect();
+                json!(reversed_range_selection)
+            })
+        }
+        None => Err(String::from("Root element is not an array")),
+    }
 }


### PR DESCRIPTION
Current implementation was indeed not ideal as it was not possible to apply different filters to multiple groups.

Given the following JSON file (example):

```json
{
  "laptops": [
    {
      "laptop": {
        "brand": "Apple",
        "options": ["a", "b", "c"]
      }
    },
    {
      "laptop": {
        "brand": "Asus",
        "options": ["d", "e", "f"]
      }
    }
  ],
  "printers": [
    {
      "printer": {
        "brand": "Epson",
        "options": ["a", "b", "c"]
      }
    },
    {
      "printer": {
        "brand": "Ricoh",
        "options": ["d", "e", "f"]
      }
    }
  ]
}
```

Running the following fine-grained command is now possible:

```sh
jql example.json "laptops|laptop.brand,printers|printer.brand"
```

Outputs:
```json
[
  [
    "Apple",
    "Asus"
  ],
  [
    "Epson",
    "Ricoh"
  ]
]
```