### PR TITLE
Null support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 > A JSON Query Language CLI tool
 
+The core philosophy of jql:
+- Keep its features as simple as possible
+- Avoid redunduncy
+- Provide meaningful error messages
+- Eat JSON as input, process, output JSON back
+
 ## Installation 🚀
 
 ```sh
@@ -241,7 +247,7 @@ jql example.json 'laptops.1:0|laptop.brand,laptops|laptop.brand'
 ]
 ```
 
-Please note that a filter is applied at the group level.
+Please note that only one filter can be applied at the group level. If you want to achieve something like `.|foo|bar`, simply go for `.|foo.bar`.
 
 ### Special characters
 
@@ -257,6 +263,12 @@ jql example.json '".valid"'
 
 ```json
 1337
+```
+
+## How to save the output
+
+```sh
+jql input.json 'foo.bar' > output.json
 ```
 
 ## Help 📖

--- a/src/array_walker.rs
+++ b/src/array_walker.rs
@@ -15,8 +15,8 @@ pub fn array_walker(
         return Err(String::from("Invalid negative array index"));
     }
 
-    // A JSON null value has been found (array).
-    if inner_json[array_index as usize] == Value::Null {
+    // No JSON value has been found (array).
+    if inner_json.get(array_index as usize).is_none() {
         let error_message = match inner_json.as_array() {
             // Trying to access an out of bound index on a node
             // or on the root element.

--- a/src/core.rs
+++ b/src/core.rs
@@ -51,6 +51,8 @@ mod tests {
 
     const SINGLE_VALUE_DATA: &str = r#"1337"#;
 
+    const SINGLE_NULL_VALUE_DATA: &str = r#"null"#;
+
     const ARRAY_DATA: &str = r#"[1, 2, 3, null]"#;
 
     const DATA: &str = r#"{
@@ -239,6 +241,17 @@ mod tests {
         let selector = Some(".");
         assert_eq!(
             Ok(json_single_value.clone()),
+            walker(&json_single_value, selector)
+        );
+    }
+
+    #[test]
+    fn get_single_null_value() {
+        let json_single_value: Value =
+            serde_json::from_str(SINGLE_NULL_VALUE_DATA).unwrap();
+        let selector = Some(".");
+        assert_eq!(
+            Ok(Value::Null),
             walker(&json_single_value, selector)
         );
     }

--- a/src/get_selection.rs
+++ b/src/get_selection.rs
@@ -32,13 +32,13 @@ pub fn get_selection(selectors: &Selectors, json: &Value) -> Selection {
                         };
                     }
 
-                    // A JSON null value has been found (non array).
-                    if inner_json[raw_selector] == Value::Null {
+                    // No JSON value has been found (non array).
+                    if inner_json.get(raw_selector).is_none() {
                         if map_index == 0 {
                             Err([
                                 "Node (",
                                 raw_selector,
-                                ") is not the root element",
+                                ") not found on the parent element",
                             ]
                                 .join(" "))
                         } else {


### PR DESCRIPTION
Previous implementation was swallowing `null` values (considered as non existing). This is now fixed.