### PR TITLE
Version macro

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,28 +1,28 @@
 use clap::{App, Arg, ArgMatches};
 
-// Should match the Cargo.toml version!
-static VERSION: &str = "0.2.2";
-
 /// Get the CLI matches.
 pub fn get_matches<'a>() -> ArgMatches<'a> {
     App::new("jql")
         .about("JSON Query Language")
         .author("Davy Duperron <yamafaktory@gmail.com>")
-        .version(VERSION)
+        .version(crate_version!())
         .arg(
             Arg::with_name("JSON")
                 .help("JSON file to use")
                 .index(1)
                 .required(true),
-        ).arg(
+        )
+        .arg(
             Arg::with_name("selectors")
                 .help("Selectors to apply")
                 .index(2)
                 .required(true),
-        ).arg(
+        )
+        .arg(
             Arg::with_name("inline")
                 .help("Inlines JSON output")
                 .long("inline")
                 .short("i"),
-        ).get_matches()
+        )
+        .get_matches()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
+#[macro_use]
 extern crate clap;
 extern crate lazy_static;
+extern crate pest;
 extern crate rayon;
 extern crate regex;
 extern crate serde_json;
-extern crate pest;
 #[macro_use]
 extern crate pest_derive;
 
@@ -14,9 +15,9 @@ mod core;
 mod flatten_json_array;
 mod get_selection;
 mod group_walker;
+mod parser;
 mod range_selector;
 mod types;
-mod parser;
 mod utils;
 
 use cli::get_matches;
@@ -57,7 +58,8 @@ fn main() {
                                 serde_json::to_string
                             } else {
                                 serde_json::to_string_pretty
-                            })(&selection).unwrap()
+                            })(&selection)
+                            .unwrap()
                         ),
                         Err(error) => println!("{}", error),
                     }


### PR DESCRIPTION
The clap crate offers a [`crate_version`](https://docs.rs/clap/*/clap/macro.crate_version.html) macro to simplify setting the binary's version.

I realized that rustfmt adjusted some of the syntax as well and can revert that if you would like. I am using the nightly version so perhaps that is why there is a difference.