### PR TITLE
Preserve order of object properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
     - rust: nightly
   fast_finish: true
 
+git:
+  depth: 10
+
 before_script:
   - rustup component add clippy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "itertools"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +598,7 @@ name = "serde_json"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -831,6 +837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"
+"checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools-num 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a872a22f9e6f7521ca557660adb96dd830e54f0f490fa115bb55dd69d38b27e7"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jql"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored_json 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "jql"
 readme = "README.md"
 repository = "https://github.com/yamafaktory/jql"
-version = "2.2.0"
+version = "2.3.0"
 
 [badges]
 travis-ci = { repository = "yamafaktory/jql" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,11 @@ lazy_static = "1.2.0"
 pest = "2.1.0"
 pest_derive = "2.1.0"
 rayon = "1.0.3"
-serde_json = "1.0.34"
+
+[dependencies.serde_json]
+version = "1.0.34"
+default-features = false
+features = ["preserve_order"]
 
 [[bench]]
 name = "benchmark"

--- a/after-success.sh
+++ b/after-success.sh
@@ -3,7 +3,7 @@
 # Clone the repository
 REMOTE_URL="$(git config --get remote.origin.url)";
 cd ${TRAVIS_BUILD_DIR}/.. && \
-git clone ${REMOTE_URL} "${TRAVIS_REPO_SLUG}-bench" --depth 10 && \
+git clone ${REMOTE_URL} "${TRAVIS_REPO_SLUG}-bench" && \
 cd  "${TRAVIS_REPO_SLUG}-bench" && \
 
 # Bench master

--- a/after-success.sh
+++ b/after-success.sh
@@ -3,7 +3,7 @@
 # Clone the repository
 REMOTE_URL="$(git config --get remote.origin.url)";
 cd ${TRAVIS_BUILD_DIR}/.. && \
-git clone ${REMOTE_URL} "${TRAVIS_REPO_SLUG}-bench" && \
+git clone ${REMOTE_URL} "${TRAVIS_REPO_SLUG}-bench" --depth 10 && \
 cd  "${TRAVIS_REPO_SLUG}-bench" && \
 
 # Bench master

--- a/after-success.sh
+++ b/after-success.sh
@@ -18,4 +18,4 @@ cargo bench --bench benchmark -- --noplot --save-baseline after && \
 cargo install critcmp --force && \
 
 # Compare the two generated benches
-critcmp benches-control benches-variable;
+critcmp before after;

--- a/after-success.sh
+++ b/after-success.sh
@@ -18,4 +18,4 @@ cargo bench --bench benchmark -- --noplot --save-baseline after && \
 cargo install critcmp --force && \
 
 # Compare the two generated benches
-cargo critcmp benches-control benches-variable;
+critcmp benches-control benches-variable;

--- a/after-success.sh
+++ b/after-success.sh
@@ -18,4 +18,4 @@ cargo bench --bench benchmark -- --noplot --save-baseline after && \
 cargo install critcmp --force && \
 
 # Compare the two generated benches
-cargo benchcmp benches-control benches-variable;
+cargo critcmp benches-control benches-variable;

--- a/src/core.rs
+++ b/src/core.rs
@@ -583,11 +583,28 @@ mod tests {
     }
 
     #[test]
+    fn get_unordered_properties_root() {
+        let json: Value = serde_json::from_str(OBJECT_DATA).unwrap();
+        let selector = Some(r#"{"b","a"}"#);
+        assert_eq!(Ok(json!({ "b": 11, "a": 7 })), walker(&json, selector));
+    }
+
+    #[test]
     fn get_properties_child_node() {
         let json: Value = serde_json::from_str(DATA).unwrap();
         let selector = Some(r#""nested".{"a","b"}"#);
         assert_eq!(
             Ok(json!({ "a": "one", "b": "two" })),
+            walker(&json, selector)
+        );
+    }
+
+    #[test]
+    fn get_unordered_properties_child_node() {
+        let json: Value = serde_json::from_str(DATA).unwrap();
+        let selector = Some(r#""nested".{"b","a"}"#);
+        assert_eq!(
+            Ok(json!({ "b": "two", "a": "one" })),
             walker(&json, selector)
         );
     }


### PR DESCRIPTION
- By default, serde_json is not preserving the entries in the order they are inserted into the map https://github.com/serde-rs/json/blob/master/src/value/mod.rs#L196-L200. Use the `preserve_order` feature flag to enable that option.
- Fix the `after_success` benchmark comparison step failure by increasing the git depth https://github.com/travis-ci/travis-ci/issues/6690.