### PR TITLE
chore: Put license specification back

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "A JSON query language CLI tool"
 edition = "2018"
 exclude = [".travis.yml", "after-success.sh", "benches/**/*", "rustfmt.toml"]
 keywords = ["CLI", "JSON", "tool", "query"]
+license = "MIT"
 license-file = "LICENSE-MIT"
 name = "jql"
 readme = "README.md"


### PR DESCRIPTION
Unfortunately pointing to the license file is not very helpful when you need to build automation around. You need to fetch the whole tarball and parse LICENSE file and hope that your parser is good.

Let's just specify license identifier explicitly.