### PR TITLE
chore: add truncate grammar and logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -114,7 +114,7 @@ dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -124,7 +124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion-plot 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -136,7 +136,7 @@ dependencies = [
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -269,13 +269,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "jql"
 version = "2.5.1"
 dependencies = [
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored_json 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -622,7 +622,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -801,7 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 "checksum colored_json 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fd32eb54d016e203b7c2600e3a7802c75843a92e38ccc4869aefeca21771a64"
 "checksum criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "63f696897c88b57f4ffe3c69d8e1a0613c7d0e6c4833363c8560fbde9c47b966"
 "checksum criterion-plot 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ddeaf7989f00f2e1d871a26a110f3ed713632feac17f65f03ca938c542618b60"
@@ -854,7 +854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)" = "f4473e8506b213730ff2061073b48fa51dcc66349219e2e7c5608f0296a1d95a"
 "checksum serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154"
-"checksum serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)" = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
+"checksum serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "yamafaktory/jql" }
 criterion = "0.3.2"
 
 [dependencies]
-clap = "2.33.0"
+clap = "2.33.1"
 colored_json = "2.1.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"
@@ -27,7 +27,7 @@ rayon = "1.3.0"
 [dependencies.serde_json]
 default-features = false
 features = ["preserve_order"]
-version = "1.0.52"
+version = "1.0.53"
 
 [[bench]]
 harness = false

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Davy Duperron
+Copyright (c) Davy Duperron
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -367,7 +367,56 @@ jql '.."dna"' example.json
 
 ### Truncate
 
-TODO
+The truncate selector `!` can be used to stop walking the children's values and to explore an unknown JSON file / structure.
+Each children is then transformed into a JSON primitive for convenience, e.g.:
+
+primitive | value                        | result
+--------- | ---------------------------- | -------
+object    | `{ "a": 1, "b": 2, "c": 3 }` | `{}`
+array     | `[1, 2, 3]`                  | `[]`
+string    | `"foo"`                      | `"foo"`
+number    | `666`                        | `666`
+null      | `null`                       | `null`
+
+```json
+{
+  "foo": {
+    "a": null,
+    "b": "bar",
+    "c": 1337,
+    "d": {
+      "woot": [
+        1,
+        2,
+        3
+      ]
+    }
+  }
+}
+```
+
+```sh
+jql '.!' example.json
+```
+
+```json
+{
+  "foo": {}
+}
+```
+
+```sh
+jql '"foo"!' example.json
+```
+
+```json
+{
+  "a": null,
+  "b": "bar",
+  "c": 1337,
+  "d": {}
+}
+```
 
 ### Special characters
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ jql '"laptops".[1:0]|"laptop"|"brand","laptops"|"laptop"|"brand"' example.json
 ]
 ```
 
-### Flattening arrays
+### Flatten arrays
 
 ```json
 {
@@ -364,6 +364,10 @@ jql '.."dna"' example.json
   "t"
 ]
 ```
+
+### Truncate
+
+TODO
 
 ### Special characters
 

--- a/src/apply_filter.rs
+++ b/src/apply_filter.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use rayon::prelude::*;
 
 /// Apply the filter selectors to a JSON value and returns a selection.
-pub fn apply_filter(
+pub fn apply_filter( 
     filter_selectors: &[Selector],
     json: &Value,
 ) -> ExtendedSelections {

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,9 +1,10 @@
-use crate::group_walker::group_walker;
-use crate::parser::selectors_parser;
-use crate::types::{Selection, Selections};
+use crate::{
+    group_walker::group_walker,
+    parser::selectors_parser,
+    types::{Selection, Selections},
+};
 use rayon::prelude::*;
-use serde_json::json;
-use serde_json::Value;
+use serde_json::{json, Value};
 
 /// Given some selectors walk over the JSON file.
 pub fn walker(json: &Value, selectors: Option<&str>) -> Selection {
@@ -680,7 +681,7 @@ mod tests {
     }
 
     #[test]
-    fn check_truncate() {
+    fn check_truncate_on_root() {
         let json: Value = serde_json::from_str(DATA).unwrap();
         let selector = Some(r#".!"#);
         assert_eq!(
@@ -704,5 +705,39 @@ mod tests {
             })),
             walker(&json, selector)
         );
+    }
+
+    #[test]
+    fn check_truncate_on_nested_value() {
+        let json: Value = serde_json::from_str(DATA).unwrap();
+        let selector = Some(r#""nested-filter".[0]."laptop"!"#);
+        assert_eq!(
+            Ok(json!({
+                "brand": "Apple",
+                "options": [],
+                "price": 9999
+            })),
+            walker(&json, selector)
+        );
+    }
+
+    #[test]
+    fn check_truncate_on_groups() {
+        let json: Value = serde_json::from_str(DATA).unwrap();
+        let selector = Some(r#""nested-filter".[0]."laptop"!, "filter"!"#);
+        assert_eq!(
+            Ok(json!([
+                {"brand": "Apple", "options": [], "price": 9999 },
+                [{},{},{}]
+            ])),
+            walker(&json, selector)
+        );
+    }
+
+    #[test]
+    fn check_truncate_with_filter() {
+        let json: Value = serde_json::from_str(DATA).unwrap();
+        let selector = Some(r#""nested-filter-to-flatten"|"fruit"!"#);
+        assert_eq!(Ok(json!([{}, {}])), walker(&json, selector));
     }
 }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -1,7 +1,7 @@
 WHITESPACE = _{ " " }
 
 groups = _{ selection ~ ("," ~ selection)* }
-    selection = { (spread? ~ root? ~ (selector ~ ("."? ~ selector)*)?)? ~ filters* }
+    selection = { (spread? ~ root? ~ (selector ~ ("."? ~ selector)*)?)? ~ filters* ~ truncate?}
         root = { "." }
 
         spread = { ".." }
@@ -33,3 +33,5 @@ groups = _{ selection ~ ("," ~ selection)* }
                 filter_default = { default }
                 filter_object = _{ "{" ~ filter_property ~ "}" }
                     filter_property = { default ~ ("," ~ default)* }
+
+        truncate = { "!" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![forbid(rust_2018_idioms)]
+#![deny(nonstandard_style)]
+#![warn(missing_debug_implementations, missing_docs)]
+
 //! # A JSON query language library
 //!
 //! This crate is used by `jql`, the `JSON query language CLI tool`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod get_selection;
 mod group_walker;
 mod parser;
 mod range_selector;
+mod truncate;
 mod types;
 mod utils;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -88,7 +88,8 @@ pub fn selectors_parser(selectors: &str) -> Result<Groups, String> {
             let mut groups: Groups = Vec::new();
 
             for pair in pairs {
-                let mut group: Group = (None, None, Vec::new(), Vec::new());
+                let mut group: Group =
+                    (None, None, Vec::new(), Vec::new(), None);
 
                 // Loop over the pairs converted as an iterator of the tokens
                 // which composed it.
@@ -129,6 +130,8 @@ pub fn selectors_parser(selectors: &str) -> Result<Groups, String> {
                         Rule::root => group.1 = Some(()),
                         // Spread
                         Rule::spread => group.0 = Some(()),
+                        // Truncate
+                        Rule::truncate => group.4 = Some(()),
                         _ => (),
                     };
                 }

--- a/src/truncate.rs
+++ b/src/truncate.rs
@@ -11,7 +11,7 @@ pub fn truncate_json(value: Value) -> Value {
         _ => value.to_owned(),
     };
 
-    match value.clone() {
+    match value {
         _ if value.is_array() => value
             .clone()
             .as_array_mut()

--- a/src/truncate.rs
+++ b/src/truncate.rs
@@ -11,7 +11,6 @@ pub fn truncate_json(mut value: Value) -> Value {
 
     match value {
         _ if value.is_array() => value
-            // .clone() 
             .as_array_mut()
             .unwrap()
             .iter()

--- a/src/truncate.rs
+++ b/src/truncate.rs
@@ -1,0 +1,74 @@
+use serde_json::json;
+use serde_json::Map;
+use serde_json::Value;
+
+/// Truncate a JSON value.
+pub fn truncate_json(value: Value) -> Value {
+    // Closure that returns the primitive of a given value.
+    let to_primitive = |value: &Value| match value {
+        _ if value.is_array() => json!([]),
+        _ if value.is_object() => json!({}),
+        _ => value.to_owned(),
+    };
+
+    match value.clone() {
+        _ if value.is_array() => value
+            .clone()
+            .as_array_mut()
+            .unwrap()
+            .iter()
+            .map(|element| to_primitive(element))
+            .collect::<Value>(),
+        _ if value.is_object() => {
+            Value::Object(value.as_object().unwrap().iter().fold(
+                Map::new(),
+                |mut acc, property| {
+                    acc.insert(
+                        property.0.to_string(),
+                        to_primitive(property.1),
+                    );
+                    acc
+                },
+            ))
+        }
+        _ => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_array() {
+        assert_eq!(
+            json!([[], {}, "woot", 7, null]),
+            truncate_json(json!([[1,2,3], {"foo":"bar"}, "woot", 7, null]))
+        );
+    }
+
+    #[test]
+    fn truncate_object() {
+        assert_eq!(
+            json!({"foo":[], "bar": {}, "woot": "what", "number": 7, "nothing": null}),
+            truncate_json(
+                json!({ "foo": [], "bar": {}, "woot": "what", "number": 7, "nothing": null})
+            )
+        );
+    }
+
+    #[test]
+    fn truncate_string() {
+        assert_eq!(json!("something"), truncate_json(json!("something")));
+    }
+
+    #[test]
+    fn truncate_number() {
+        assert_eq!(json!(7), truncate_json(json!(7)));
+    }
+
+    #[test]
+    fn truncate_null() {
+        assert_eq!(json!(null), truncate_json(json!(null)));
+    }
+}

--- a/src/truncate.rs
+++ b/src/truncate.rs
@@ -1,9 +1,7 @@
-use serde_json::json;
-use serde_json::Map;
-use serde_json::Value;
+use serde_json::{json, Map, Value};
 
 /// Truncate a JSON value.
-pub fn truncate_json(value: Value) -> Value {
+pub fn truncate_json(mut value: Value) -> Value {
     // Closure that returns the primitive of a given value.
     let to_primitive = |value: &Value| match value {
         _ if value.is_array() => json!([]),
@@ -13,7 +11,7 @@ pub fn truncate_json(value: Value) -> Value {
 
     match value {
         _ if value.is_array() => value
-            .clone()
+            // .clone() 
             .as_array_mut()
             .unwrap()
             .iter()

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,6 +49,8 @@ pub type Group = (
     Vec<Selector>,
     // Filters part.
     Vec<Selector>,
+    // Truncate part.
+    Option<()>,
 );
 
 pub type Groups = Vec<Group>;
@@ -64,4 +66,3 @@ pub type Selection = Result<Value, String>;
 pub type Selections = Result<Vec<Value>, String>;
 
 pub type ExtendedSelections = Result<MaybeArray, String>;
-


### PR DESCRIPTION
This PR aims at providing a new feature, as described in #39.

A new operator will be available (`!`), that one can put at the end of any group.

E.g. with a simple selector with only one group `"foo"!` applied to following JSON input:
```json
{ "foo": { "a": { "x": 1 }, "b": [1, 2, 3], "c": "woot", "d": 7, "e": null } }
```
Will return:
```json
{ "foo": { "a": {}, "b": [], "c": "woot", "d": 7, "e": null } }
```
What's missing before publishing:
- [x] Documentation
- [x] More granular tests