### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,7 +19,9 @@ jobs:
           - target: x86_64-apple-darwin
             archive: zip
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
+        with:
+          ref: "main"
       - name: Compile and release
         uses: rust-build/rust-build.action@latest
         env:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,8 +20,6 @@ jobs:
             archive: zip
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: "main"
       - name: Compile and release
         uses: rust-build/rust-build.action@latest
         env:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,28 @@
+name: build release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-release:
+    name: Release ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-pc-windows-gnu
+            archive: zip
+          - target: x86_64-unknown-linux-musl
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            archive: zip
+    steps:
+      - uses: actions/checkout@master
+      - name: Compile and release
+        uses: rust-build/rust-build.action@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUSTTARGET: ${{ matrix.target }}
+          ARCHIVE_TYPES: ${{ matrix.archive }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,13 @@ jobs:
           labels: enhancement
           reviewers: yamafaktory
           branch: performance
+
+  publish-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Release
         uses: softprops/action-gh-release@v1
         env:


### PR DESCRIPTION
Re.: #140 

Publishes a release on pushed version tags and builds binaries for that release. The workflow uses [rust-build.action](https://github.com/rust-build/rust-build.action), which means the supported triples are:

- `x86_64-pc-windows-gnu`
- `x86_64-unknown-linux-musl`
- `x86_64-apple-darwin`

Optimally, `aarch64-*` should be supported as well, but this has proven hard to cross-compile (after a lot of trial and error.) Either way, building for `x86` is a step in the right direction, and hopefully rust-build.action will support more triples in the future.