### PR TITLE
ci: release: Add arm-unknown-linux-musleabihf target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,11 @@ jobs:
           archive: tar.gz
           archive-cmd: tar czf
           sha-cmd: sha256sum
+        - os: ubuntu-latest
+          target: arm-unknown-linux-musleabihf
+          archive: tar.gz
+          archive-cmd: tar czf
+          sha-cmd: sha256sum
 
         # Darwin
         - os: macos-latest


### PR DESCRIPTION
Such target is important for arm boards that are not 64bits