### PR TITLE
fix(win): fix Windows release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          fail_on_unmatched_files: true
           files: |
             ${{ env.ASSET_PATH }}
             ${{ env.CHECKSUM_PATH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,8 @@ jobs:
           cd $src
           ${{ matrix.sha-cmd }} $asset_name > $CHECKSUM_PATH
           if [ "$RUNNER_OS" == "Windows" ]; then
-            echo "ASSET_PATH=$(cygpath -w $ASSET_PATH)" >> $GITHUB_ENV
-            echo "CHECKSUM_PATH=$(cygpath -w $CHECKSUM_PATH)" >> $GITHUB_ENV
+            echo "ASSET_PATH=$(cygpath -m $ASSET_PATH)" >> $GITHUB_ENV
+            echo "CHECKSUM_PATH=$(cygpath -m $CHECKSUM_PATH)" >> $GITHUB_ENV
           else
             echo "ASSET_PATH=$ASSET_PATH" >> $GITHUB_ENV
             echo "CHECKSUM_PATH=$CHECKSUM_PATH" >> $GITHUB_ENV


### PR DESCRIPTION
1. Switch to using forward slashes in PATH-variables on releasing Windows binaries.
Fixes #217.
Tested [here](https://github.com/aliesbelik/jql/actions/runs/4867208765/jobs/8679564013).

2. Additionally force release action to fail if files are missing.
Surprisingly corresponding option - `fail_on_unmatched_files` - set to [false by default](https://github.com/softprops/action-gh-release#-customizing).
I wonder it's more preferable to fail loudly than silently create a incomplete release.
Refers to #217, #188.
Tested [here](https://github.com/aliesbelik/jql/actions/runs/4878257527/jobs/8703738650).