### PR TITLE
fix(release): don't use cross for Darwin and Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,10 +90,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build
+      - name: Build Linux
+        if: matrix.os == 'ubuntu-latest'
         run: |
           cargo install cross --git https://github.com/cross-rs/cross
           cross build --release --target ${{ matrix.target }}
+      
+      - name: Build Darwin & Windows
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package Artifacts
         shell: bash


### PR DESCRIPTION
The Darwin and Windows binaries were wrongly built using `cross` - which has never supported those out of the box and was triggering a warning.

The latest release failed for those targets since `cross` is now throwing an error. In the end, `cross` is not needed for those targets and can simply replaced by `cargo`.