### PR TITLE
fix(key-order): adjust tests and code to properly keep ordered keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "rayon",
 ]
 
 [[package]]
@@ -404,6 +405,7 @@ name = "jql-runner"
 version = "7.1.10"
 dependencies = [
  "criterion",
+ "indexmap",
  "jql-parser",
  "rayon",
  "serde_json",
@@ -721,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -734,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -935,9 +937,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ version = "7.1.10"
 [workspace.lints.rust]
 missing_debug_implementations = "warn"
 missing_docs = "warn"
-nonstandard_style = "deny"
-rust_2021_compatibility = "forbid"
+nonstandard_style = { level = "deny", priority= -1 }
+rust_2021_compatibility = { level = "forbid", priority= -1 }
 unreachable_pub = "warn"
 unsafe_code = "deny"
 

--- a/crates/jql-parser/Cargo.toml
+++ b/crates/jql-parser/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-authors = { workspace = true }
-categories = { workspace = true }
+authors.workspace = true
+categories.workspace = true
 description = "Parser for jql - the JSON Query Language tool."
-edition = { workspace = true }
-keywords = { workspace = true }
-license = { workspace = true }
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
 name = "jql-parser"
-readme = { workspace = true }
-repository = { workspace = true }
-version = { workspace = true }
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
-thiserror = { workspace = true }
-winnow = { version = "0.6.8", features = ["simd"] }
+thiserror.workspace = true
+winnow = { version = "0.6.9", features = ["simd"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/jql-runner/Cargo.toml
+++ b/crates/jql-runner/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
-authors = { workspace = true }
-categories = { workspace = true }
+authors.workspace = true
+categories.workspace = true
 description = "Runner for jql - the JSON Query Language tool."
-edition = { workspace = true }
-keywords = { workspace = true }
-license = { workspace = true }
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
 name = "jql-runner"
-readme = { workspace = true }
-repository = { workspace = true }
-version = { workspace = true }
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
+indexmap = { version = "2.2.6", features = ["rayon"] }
 jql-parser = { path = "../jql-parser", version = "7.1.10" }
 rayon = "1.10.0"
-serde_json = { workspace = true }
-thiserror = { workspace = true }
+serde_json.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/crates/jql/Cargo.toml
+++ b/crates/jql/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-authors = { workspace = true }
-categories = { workspace = true }
+authors.workspace = true
+categories.workspace = true
 description = "jql - JSON Query Language - is a fast and simple command-line tool to manipulate JSON data."
-edition = { workspace = true }
-keywords = { workspace = true }
-license = { workspace = true }
+edition.workspace = true
+keywords.workspace = true
+license.workspace = true
 name = "jql"
-readme = { workspace = true }
-repository = { workspace = true }
-version = { workspace = true }
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.4", features = ["derive"] }
 colored_json = { version = "5.0.0" }
 jql-runner = { path = "../jql-runner", version = "7.1.10" }
-serde = "1.0.202"
+serde = "1.0.203"
 serde_stacker = "0.1.11"
-serde_json = { workspace = true }
-tokio = { version = "1.37.0", features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"] }
+serde_json.workspace = true
+tokio = { version = "1.38.0", features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"] }

--- a/justfile
+++ b/justfile
@@ -1,3 +1,7 @@
+# Clippy.
+clippy:
+  cargo clippy
+
 # Fuzz parser.
 fuzz:
   cargo fuzz run fuzz_parser


### PR DESCRIPTION
This PR addresses some issues that were not properly checked in the tests. The following functions of the runner were not keeping the order while processing the data:
- Multi key selector
- Object index selector
- Object range selector

The culprit is that the tests were incorrectly relying on equality in assertion using the `json!` macro. Something like that would be considered as valid:

```rust
assert_eq!(json!({"a": 1, "b": 2}), json!({"b": 2, "a": 1}));
```

Since the aforementioned functions were all relying on the `par_bridge` method from `rayon` - which doesn't guaranty to keep the order of the original iterator - the tests were successful while incorrect.

Here's a playground to reproduce the issue: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=e0f3bda5f381e1751e40b5bc4ac92687
