### PR TITLE
add support for cargo-binstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ yay -S jql
 cargo install jql
 ```
 
+### Cargo Binstall
+
+```sh
+cargo binstall jql
+```
+
 ### Fedora
 
 ```sh

--- a/crates/jql/Cargo.toml
+++ b/crates/jql/Cargo.toml
@@ -19,3 +19,6 @@ serde = "1.0.203"
 serde_stacker = "0.1.11"
 serde_json.workspace = true
 tokio = { version = "1.38.0", features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread"] }
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"


### PR DESCRIPTION
I will like to download jql using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall).

Normally it should work without adding the metadata, but jql use a different structure for tags.

This is the documentation:
https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md